### PR TITLE
Update statement on odd-numbered updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ rare and will land as *semver-minor* bumps in the LTS covered version.
 All LTS releases will be assigned a codename. A list of expected upcoming
 codenames is available in [CODENAMES.md](./CODENAMES.md).
 
-An odd-numbered major release will recieve security updates for approxamately three months once the
+An odd-numbered major release will receive security updates for approximately three months once the
 subsequent even-numbered major release is cut.
 
 ### LTS Staging Branches

--- a/README.md
+++ b/README.md
@@ -116,8 +116,10 @@ rare and will land as *semver-minor* bumps in the LTS covered version.
 All LTS releases will be assigned a codename. A list of expected upcoming
 codenames is available in [CODENAMES.md](./CODENAMES.md).
 
-An odd-numbered major release will _only_ receive needed security updates for approximately three months once the
-subsequent even-numbered major release is cut. Otherwise, odd-numbered major releases will cease to receive updates.
+An odd-numbered major release will cease to be actively updated when the subsequent
+even-numbered major release is cut. Depending on circumstances the project may
+decide to provide an update to the odd-numbered release after the cutoff. However, 
+there is no guarantee that any release will be made.
 
 ### LTS Staging Branches
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ All LTS releases will be assigned a codename. A list of expected upcoming
 codenames is available in [CODENAMES.md](./CODENAMES.md).
 
 An odd-numbered major release will _only_ receive needed security updates for approximately three months once the
-subsequent even-numbered major release is cut. Otherwise, odd-numbered major releases will cease to recieve updates.
+subsequent even-numbered major release is cut. Otherwise, odd-numbered major releases will cease to receive updates.
 
 ### LTS Staging Branches
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,7 @@ rare and will land as *semver-minor* bumps in the LTS covered version.
 All LTS releases will be assigned a codename. A list of expected upcoming
 codenames is available in [CODENAMES.md](./CODENAMES.md).
 
-An odd-numbered major release will cease to be actively updated when the
+An odd-numbered major release will recieve security updates for approxamately three months once the
 subsequent even-numbered major release is cut.
 
 ### LTS Staging Branches

--- a/README.md
+++ b/README.md
@@ -116,8 +116,8 @@ rare and will land as *semver-minor* bumps in the LTS covered version.
 All LTS releases will be assigned a codename. A list of expected upcoming
 codenames is available in [CODENAMES.md](./CODENAMES.md).
 
-An odd-numbered major release will receive security updates for approximately three months once the
-subsequent even-numbered major release is cut.
+An odd-numbered major release will _only_ receive needed security updates for approximately three months once the
+subsequent even-numbered major release is cut. Otherwise, odd-numbered major releases will cease to recieve updates.
 
 ### LTS Staging Branches
 


### PR DESCRIPTION
This updates a statement that odd-numbered releases are fully EOL once the next even-numbered release is cut. This seems to be reflected in the [release schedule](https://github.com/nodejs/Release/blob/master/schedule.json#L44), and in a [twitter thread](https://twitter.com/MylesBorins/status/989191105152520192) discussing this topic.