### PR TITLE
Add "Dubnium" Codename to v10.0.0 in schedule.json

### DIFF
--- a/schedule.json
+++ b/schedule.json
@@ -48,6 +48,6 @@
     "lts": "2018-10-01",
     "maintenance": "2020-04-01",
     "end": "2021-04-01",
-    "codename": ""
+    "codename": "Dubnium"
   }
 }


### PR DESCRIPTION
If I understand correctly, this should make `lts/dubnium` work with NVM, and thus TravisCI and the many others that rely on it.