### PR TITLE
doc: move v9.x to EOL

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@
 | :--:     | :---:               | :---:      | :---:          | :---:            | :---:                 | :---:                     |
 | [6.x][]  | **Maintenance LTS** | [Boron][]  | 2016-04-26     | 2016-10-18       | 2018-04-30            | April 2019                |
 | [8.x][]  | **Active LTS**      | [Carbon][] | 2017-05-30     | 2017-10-31       | April 2019            | December 2019<sup>1</sup> |
-| 9.x      | **Maintenance**     |            | 2017-10-01     |                  |                       | June 2018                 |
 | [10.x][] | **Current Release** | Dubnium    | 2018-04-24     | October 2018     | April 2020            | April 2021                |
 | 11.x     | **Pending**         |            | 2018-10-23     |                  |                       | June 2019                 |
 
@@ -31,6 +30,7 @@ is generated using the [lts module][].
 | [4.x][] | **End-of-Life**     | [Argon][]  | 2015-09-08     | 2015-10-01       | 2017-04-01            | 2018-04-30                |
 | 5.x     | **End-of-Life**     |            | 2015-10-29     |                  |                       | 2016-06-30                |
 | 7.x     | **End-of-Life**     |            | 2016-10-25     |                  |                       | 2017-06-30                |
+| 9.x     | **End-of-Life**     |            | 2017-10-01     |                  |                       | 2018-06-30                |
 
 ## Mandate
 


### PR DESCRIPTION
2018-06-30 has passed, it's July now.

_That depends on the time zone you are in, but there won't be any more 9.x releases afaik._
_Also, this needs time to land._