### PR TITLE
chore: Add Dubnium codename to schedule.json

### DIFF
--- a/schedule.json
+++ b/schedule.json
@@ -48,7 +48,7 @@
     "lts": "2018-10-01",
     "maintenance": "2020-04-01",
     "end": "2021-04-01",
-    "codename": ""
+    "codename": "Dubnium"
   },
   "v11": {
     "start": "2018-10-23",


### PR DESCRIPTION
Although the LTS hasn't started, the name appears to be used in other parts of the repo already