### PR TITLE
Target release date for 12.0.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 | [6.x][]  | **Maintenance LTS** | [Boron][]  | 2016-04-26     | 2016-10-18       | 2018-04-30            | April 2019                |
 | [8.x][]  | **Active LTS**      | [Carbon][] | 2017-05-30     | 2017-10-31       | April 2019            | December 2019<sup>1</sup> |
 | [10.x][] | **Current Release** | Dubnium    | 2018-04-24     | October 2018     | April 2020            | April 2021                |
-| 11.x     | **Pending**         |            | 2018-10-23     |                  |                       | June 2019                 |
+| 11.x     | **Current Release** |            | 2018-10-23     |                  |                       | June 2019                 |
+| 12.x     | **Pending**         |            | 2019-04-23     | October 2019     | April 2021            | April 2022                |
 
 Dates are subject to change.
 


### PR DESCRIPTION
@nodejs/collaborators ... the Target release date will be April 23rd, 2019.

@BethGriggs ... are you still interested in helping do the 12.0.0 release? I'm happy to mentor you through the process.