### PR TITLE
changing 10.x status to Active LTS in Release schedule

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | :--:     | :---:               | :---:      | :---:          | :---:            | :---:                 | :---:                     |
 | [6.x][]  | **Maintenance LTS** | [Boron][]  | 2016-04-26     | 2016-10-18       | 2018-04-30            | April 2019                |
 | [8.x][]  | **Active LTS**      | [Carbon][] | 2017-05-30     | 2017-10-31       | April 2019            | December 2019<sup>1</sup> |
-| [10.x][] | **Current Release** | Dubnium    | 2018-04-24     | 2018-10-30       | April 2020            | April 2021                |
+| [10.x][] | **Active LTS** | Dubnium    | 2018-04-24     | 2018-10-30       | April 2020            | April 2021                |
 | [11.x][] | **Current Release** |            | 2018-10-23     |                  |                       | June 2019                 |
 | 12.x     | **Pending**         |            | 2019-04-23     | October 2019     | April 2021            | April 2022                |
 


### PR DESCRIPTION
Nodejs 10.x started Active LTS mode today #381 