### PR TITLE
doc: add link to Dubnium LTS release download via nodejs/nodejs-latest-linker#2

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,13 +2,13 @@
 
 ## Release schedule
 
-| Release  | Status              | Codename   |Initial Release | Active LTS Start | Maintenance LTS Start | End-of-life               |
-| :--:     | :---:               | :---:      | :---:          | :---:            | :---:                 | :---:                     |
-| [6.x][]  | **Maintenance LTS** | [Boron][]  | 2016-04-26     | 2016-10-18       | 2018-04-30            | April 2019                |
-| [8.x][]  | **Active LTS**      | [Carbon][] | 2017-05-30     | 2017-10-31       | April 2019            | December 2019<sup>1</sup> |
-| [10.x][] | **Active LTS** | Dubnium    | 2018-04-24     | 2018-10-30       | April 2020            | April 2021                |
-| [11.x][] | **Current Release** |            | 2018-10-23     |                  |                       | June 2019                 |
-| 12.x     | **Pending**         |            | 2019-04-23     | October 2019     | April 2021            | April 2022                |
+| Release  | Status              | Codename    |Initial Release | Active LTS Start | Maintenance LTS Start | End-of-life               |
+| :--:     | :---:               | :---:       | :---:          | :---:            | :---:                 | :---:                     |
+| [6.x][]  | **Maintenance LTS** | [Boron][]   | 2016-04-26     | 2016-10-18       | 2018-04-30            | April 2019                |
+| [8.x][]  | **Active LTS**      | [Carbon][]  | 2017-05-30     | 2017-10-31       | April 2019            | December 2019<sup>1</sup> |
+| [10.x][] | **Active LTS**      | [Dubnium][] | 2018-04-24     | 2018-10-30       | April 2020            | April 2021                |
+| [11.x][] | **Current Release** |             | 2018-10-23     |                  |                       | June 2019                 |
+| 12.x     | **Pending**         |             | 2019-04-23     | October 2019     | April 2021            | April 2022                |
 
 Dates are subject to change.
 
@@ -149,6 +149,7 @@ any given point in time, fully support a maximum of 2 LTS releases.
 [Argon]: https://nodejs.org/download/release/latest-argon/
 [Boron]: https://nodejs.org/download/release/latest-boron/
 [Carbon]: https://nodejs.org/download/release/latest-carbon/
+[Dubnium]: https://nodejs.org/download/release/latest-dubnium/
 [4.x]: https://nodejs.org/download/release/latest-v4.x/
 [6.x]: https://nodejs.org/download/release/latest-v6.x/
 [8.x]: https://nodejs.org/download/release/latest-v8.x/


### PR DESCRIPTION
note, nodejs/nodejs-latest-linker#2 needs to land before this link will work