### PR TITLE
doc: switch to archived version of an rvagg meeting

### DIFF
--- a/doc/meetings/2015-06-29.md
+++ b/doc/meetings/2015-06-29.md
@@ -1,6 +1,6 @@
 # Node.js Foundation LTS Meeting Minutes 2015-06-29
 
-Recording: http://www.youtube.com/watch?v=lOSNxWtE0vU
+Recording: https://youtu.be/L_8eDAFhCwc
 
 ## Present
 


### PR DESCRIPTION
Was recorded under my soon to be inactive NodeSource account, archived under the Node.js Foundation account for posterity.

Ref https://github.com/nodejs/TSC/pull/631