### PR TITLE
doc: update to reflect N-API

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,11 +112,18 @@ weeks before being backported. It is possible for a commit to land earlier at
 the discretion of the Release working group and the maintainers of the LTS branches.
 
 Once a release moves into Maintenance mode, only ***critical*** bugs,
-***critical*** security fixes, and documentation updates will be permitted.
+***critical*** security fixes, documentation updates, and updates to ensure
+consistency and usability of the N-API across LTS releases will be permitted.
+Unless a change is ***urgent*** it will be planned into a release once per
+quarter. Such releases will only be made when necessary.
 
 Note that while it is possible that critical security and bug fixes may lead to
 *semver-major* changes landing within an LTS stream, such situations will be
 rare and will land as *semver-minor* bumps in the LTS covered version.
+
+Upates to ensure consistency and usability of the N-API across LTS releases
+are allowed as it is important to ensure that N-API native modules can be used
+across LTS versions in order to support adoption.
 
 All LTS releases will be assigned a codename. A list of expected upcoming
 codenames is available in [CODENAMES.md](./CODENAMES.md).

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Note that while it is possible that critical security and bug fixes may lead to
 *semver-major* changes landing within an LTS stream, such situations will be
 rare and will land as *semver-minor* bumps in the LTS covered version.
 
-Upates to ensure consistency and usability of the N-API across LTS releases
+Updates to ensure consistency and usability of the N-API across LTS releases
 are allowed as it is important to ensure that N-API native modules can be used
 across LTS versions in order to support adoption.
 


### PR DESCRIPTION
Update to indicate that changes for N-API will be allowed
in Maintenance when necessary.

In the last release WG meeting I took the issue to open this.