### PR TITLE
Proposal to update staging branches

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,21 +133,23 @@ even-numbered major release is cut. Depending on circumstances the project may
 decide to provide an update to the odd-numbered release after the cutoff. However, 
 there is no guarantee that any release will be made.
 
-### LTS Staging Branches
+### Staging Branches
 
-Every LTS major version has two branches in the GitHub repository: a release
-branch and a staging branch. The release branch is used to cut new releases.
-Only members of the @nodejs/releasers team should land commits onto release branches.
-The staging branch is used to land cherry-picked or backported commits from
+Every major version has three branches in the GitHub repository: a release branch
+and two staging branches. The release branch is used to cut new releases. Only
+members of the @nodejs/releasers team should land commits onto release branches.
+The staging branches are used to land cherry-picked or backported commits from
 master that need to be included in a future release. Only members of
-@nodejs/backporters should land commits onto staging branches.
+@nodejs/releasers should land commits onto staging branches.
 
-For example, for Node.js v4, there is a `v4.x` branch and a `v4.x-staging`
-branch. When commits land in master that must be cherry-picked for a future
-Node.js v4 release, those must be landed into the `v4.x-staging` branch. When
-commits are backported for a future Node.js v4 release, those must come in the
-form of pull requests opened against the `v4.x-staging` branch. **Commits are
-only landed in the `v4.x` branch when a new `v4.x` release is being prepared.**
+For example, for Node.js v10, there is a `v10.x` branch and a `v10.x-staging-patch`
+and `v10.x-staging-minor` branch. When commits land in master that must
+be cherry-picked for a future Node.js v10 release, all patch commits must be landed
+in the `v10.x-staging-patch` branch while all semver-minor and patch commits must be
+landed in the `v10.x-staging-minor` branch. When commits are backported for a future
+Node.js v10 release, those must come in the form of pull requests opened against the
+`v10.x-staging-minor` branch. **Commits are only landed in the `v10.x` branch when a
+new `v10.x` release is being prepared.**
 
 [Argon]: https://nodejs.org/download/release/latest-argon/
 [Boron]: https://nodejs.org/download/release/latest-boron/


### PR DESCRIPTION
This is a proposal to update staging branches in a way that it should become easier to handle multiple release lines next to each other (semver-minor and patch releases). This is done by using two staging branches instead of one.

The minor one is the one in which each commit that should ever be backported should be targeted against. For patch releases we cut a release from the minor branch. That should a) reduce the conflicts for semver-minor releases and b) allow commits to land directly instead of having to wait until a release to be merged.

On top of that I loosened the rule that only LTS members should land PRs on the LTS branches. Having a few more people being able to do that seems like a good step forward. I personally would actually like to extend this by allowing any collaborator to land PRs against non-LTS staging branches.

I also changed the staging branches description not be generic. So far this only described the current state for the LTS staging branches even though the other release lines behaved AFAIK identical.

----

We discussed this in the today's meeting and this is the first documentation update to go in that direction. If we agree upon this, we'll have to also update the documentation in Node.js and update the staging branches accordingly.

@nodejs/releasers PTAL