### PR TITLE
doc: remove incorrect information from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ major version transitions to the Long Term Support plan.
 
 Every major version covered by the LTS plan will be actively maintained for a
 period of 18 months from the date it enters LTS coverage. Following those 18
-months of active support, the major version will transition into "maintenance"
+months of active support, the major version will transition into Maintenance
 mode for 12 additional months.
 
 The exact date that a release stream will be moved to LTS, moved between LTS

--- a/README.md
+++ b/README.md
@@ -94,19 +94,6 @@ Once a major version enters LTS coverage, new features (semver-minor) may only
 be landed with consent of the Release working group. No semver-major
 changes other than those required for critical security fixes may be landed.
 
-Changes in an LTS-covered major version are limited to:
-
-1. Bug fixes;
-2. Security updates;
-3. Non-semver-major npm updates;
-4. Relevant documentation updates;
-5. Certain performance improvements where the risk of breaking existing
-   applications is minimal;
-6. Changes that introduce large amount of code churn where the risk of breaking
-   existing applications is low and where the change in question may
-   significantly ease the ability to backport future changes due to the
-   reduction in diff noise.
-
 Generally changes are expected to live in a *Current* release for at least 2
 weeks before being backported. It is possible for a commit to land earlier at
 the discretion of the Release working group and the maintainers of the LTS branches.


### PR DESCRIPTION
The README had a list that was supposedly the only types of changes that
land in LTS branches. However, other types of changes have landed there
routinely. Rather than try to codify, removal is a tacit acceptance that
we land whatever Release WG deems appropriate.

Refs: https://github.com/nodejs/Release/issues/405#issuecomment-474517315
Refs: https://github.com/nodejs/Release/issues/405#issuecomment-474572632

@MylesBorins @devsnek 