### PR TITLE
doc: sync team membership (remove rvagg, add jasnell)

### DIFF
--- a/README.md
+++ b/README.md
@@ -178,7 +178,6 @@ and CITGM team members listed below.
 - [@mhdawson](https://github.com/mhdawson) - Michael Dawson
 - [@MylesBorins](https://github.com/MylesBorins) - Myles Borins
 - [@othiym23](https://github.com/othiym23) - Forrest L Norvell
-- [@rvagg](https://github.com/rvagg) - Rod Vagg
 - [@sam-github](https://github.com/sam-github) - Sam Roberts
 - [@shigeki](https://github.com/shigeki) - Shigeki Ohtsu
 - [@srl295](https://github.com/srl295) - Steven R. Loomis
@@ -195,7 +194,6 @@ and CITGM team members listed below.
 - [@BethGriggs](https://github.com/BethGriggs) - Bethany Nicolle Griggs
 - [@codebytere](https://github.com/codebytere) - Shelley Vohr
 - [@gibfahn](https://github.com/gibfahn) - Gibson Fahnestock
-- [@jasnell](https://github.com/jasnell) - James M Snell
 - [@mhdawson](https://github.com/mhdawson) - Michael Dawson
 - [@MylesBorins](https://github.com/MylesBorins) - Myles Borins
 - [@sam-github](https://github.com/sam-github) - Sam Roberts


### PR DESCRIPTION
removing myself from this team, it's been a good ride but I'm dead weight at this point and I'm happy to see there's energy in here for doing this work

`ncu-team` has added @jasnell during the edit, I presume that's a correct reflection of the team.