### PR TITLE
doc: transfer 11.x to End-of-Life Releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ The Release schedule is available also as a [JSON][] file.
 |  [6.x][] | **End-of-Life** | [Boron][] |    2016-04-26   |    2016-10-18    |       2018-04-30      |  2019-04-30 |
 |  [7.x][] | **End-of-Life** |           |    2016-10-25   |                  |                       |  2017-06-30 |
 |   [9.x]  | **End-of-Life** |           |    2017-10-01   |                  |                       |  2018-06-30 |
-| [11.x][] | **End-of-Life** |           |    2018-10-23   |                  |        May 2019       |  2019-06-01 |
+| [11.x][] | **End-of-Life** |           |    2018-10-23   |                  |                       |  2019-06-01 |
 
 
 ## Mandate

--- a/README.md
+++ b/README.md
@@ -3,12 +3,11 @@
 ## Release schedule
 
 | Release  | Status              | Codename    |Initial Release | Active LTS Start | Maintenance Start | End-of-life                |
-| :--:     | :---:               | :---:       | :---:          | :---:            | :---:                 | :---:                      |
+| :--:     | :---:               | :---:       | :---:          | :---:            | :---:                 | :---:                     |
 | [8.x][]  | **Maintenance LTS** | [Carbon][]  | 2017-05-30     | 2017-10-31       | 2019-01-01            | December 2019<sup>1</sup> |
 | [10.x][] | **Active LTS**      | [Dubnium][] | 2018-04-24     | 2018-10-30       | April 2020            | April 2021                |
-| [11.x][] | **Current Release** |             | 2018-10-23     |                  | May 2019              | 2019-06-01                |
 | [12.x][] | **Current Release** |             | 2019-04-23     | 2019-10-22       | April 2021            | April 2022                |
-| 13.x     | **Pending**         |             | 2019-10-22     |                  |                       | June 2020                  |
+| 13.x     | **Pending**         |             | 2019-10-22     |                  |                       | June 2020                 |
 | 14.x     | **Pending**         |             | April 2020     | October 2020     | April 2022            | April 2023                |
 
 Dates are subject to change.
@@ -23,15 +22,17 @@ The Release schedule is available also as a [JSON][] file.
 
 ### End-of-Life Releases
 
-| Release | Status              | Codename   |Initial Release | Active LTS Start | Maintenance LTS Start | End-of-life                 |
-| :--:    | :---:               | :---:      | :---:          | :---:            | :---:                 | :---:                       |
-| v0.10.x | **End-of-Life**     | -          | 2013-03-11     | -                | 2015-10-01            | 2016-10-31                 |
-| v0.12.x | **End-of-Life**     | -          | 2015-02-06     | -                | 2016-04-01            | 2016-12-31                 |
-| [4.x][] | **End-of-Life**     | [Argon][]  | 2015-09-08     | 2015-10-01       | 2017-04-01            | 2018-04-30                 |
-| [5.x][] | **End-of-Life**     |            | 2015-10-29     |                  |                       | 2016-06-30                 |
-| [6.x][] | **End-of-Life** | [Boron][]  | 2016-04-26     | 2016-10-18       | 2018-04-30            | 2019-04-30                 |
-| [7.x][] | **End-of-Life**     |            | 2016-10-25     |                  |                       | 2017-06-30                 |
-| [9.x]   | **End-of-Life**     |            | 2017-10-01     |                  |                       | 2018-06-30                 |
+|  Release |      Status     |  Codename | Initial Release | Active LTS Start | Maintenance LTS Start | End-of-life |
+|:--------:|:---------------:|:---------:|:---------------:|:----------------:|:---------------------:|:-----------:|
+|  v0.10.x | **End-of-Life** |     -     |    2013-03-11   |         -        |       2015-10-01      |  2016-10-31 |
+|  v0.12.x | **End-of-Life** |     -     |    2015-02-06   |         -        |       2016-04-01      |  2016-12-31 |
+|  [4.x][] | **End-of-Life** | [Argon][] |    2015-09-08   |    2015-10-01    |       2017-04-01      |  2018-04-30 |
+|  [5.x][] | **End-of-Life** |           |    2015-10-29   |                  |                       |  2016-06-30 |
+|  [6.x][] | **End-of-Life** | [Boron][] |    2016-04-26   |    2016-10-18    |       2018-04-30      |  2019-04-30 |
+|  [7.x][] | **End-of-Life** |           |    2016-10-25   |                  |                       |  2017-06-30 |
+|   [9.x]  | **End-of-Life** |           |    2017-10-01   |                  |                       |  2018-06-30 |
+| [11.x][] | **End-of-Life** |           |    2018-10-23   |                  |        May 2019       |  2019-06-01 |
+
 
 ## Mandate
 


### PR DESCRIPTION
According to the release schedule, 11.x is End-of-Life starting at the 2019-06-01.
This commit reflects this change in the `README.md` by moving 11.x from the Release schedule to the End-of-Life Releases.

Fixes https://github.com/nodejs/Release/issues/453