### PR TITLE
doc: clarify LTS bit flip process

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ odd-numbered versions (e.g. v5, v7, v9) are cut in October.
 In co-ordination with a new *odd-numbered* major release being cut, the
 previous *even-numbered* major version will transition to the Long Term Support
 plan. The transition to Long Term Support can happen either before or after
-the new major-version is cut in a Semver-Minor release following
+the new major version is cut in a Semver-Minor release following
 [the process documented below])(#marking-a-release-line-as-lts).
 
 Every major version covered by the LTS plan will be actively maintained for a

--- a/README.md
+++ b/README.md
@@ -78,8 +78,11 @@ New semver-major releases of Node.js are cut from `master` every six months.
 New even-numbered versions (e.g. v6, v8, v10, etc) are cut in April. New
 odd-numbered versions (e.g. v5, v7, v9) are cut in October.
 
-When a new *odd-numbered* major release is cut, the previous *even-numbered*
-major version transitions to the Long Term Support plan.
+In co-ordination with a new *odd-numbered* major release being cut, the
+previous *even-numbered* major version will transition to the Long Term Support
+plan. The transition to Long Term Support can happen either before or after
+the new major-version is cut in a Semver-Minor release following
+[the process documented below])(#marking-a-release-line-as-lts).
 
 Every major version covered by the LTS plan will be actively maintained for a
 period of 18 months from the date it enters LTS coverage. Following those 18

--- a/README.md
+++ b/README.md
@@ -78,7 +78,7 @@ New semver-major releases of Node.js are cut from `master` every six months.
 New even-numbered versions (e.g. v6, v8, v10, etc) are cut in April. New
 odd-numbered versions (e.g. v5, v7, v9) are cut in October.
 
-In co-ordination with a new *odd-numbered* major release being cut, the
+In coordination with a new *odd-numbered* major release being cut, the
 previous *even-numbered* major version will transition to the Long Term Support
 plan. The transition to Long Term Support can happen either before or after
 the new major version is cut in a Semver-Minor release following


### PR DESCRIPTION
Outline that the LTS release can happen either before or after
the current release is cut.

Closes: https://github.com/nodejs/Release/issues/495