### PR TITLE
doc: move Evan Lucas to emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,7 +249,6 @@ and CITGM team members listed below.
 - [@BridgeAR](https://github.com/BridgeAR) - Ruben Bridgewater
 - [@cjihrig](https://github.com/cjihrig) - Colin Ihrig
 - [@codebytere](https://github.com/codebytere) - Shelley Vohr
-- [@evanlucas](https://github.com/evanlucas) - Evan Lucas
 - [@Fishrock123](https://github.com/Fishrock123) - Jeremiah Senkpiel
 - [@gibfahn](https://github.com/gibfahn) - Gibson Fahnestock
 - [@jasnell](https://github.com/jasnell) - James M Snell
@@ -281,6 +280,7 @@ and CITGM team members listed below.
 - [@rvagg](https://github.com/rvagg) - Rod Vagg
 
 #### Releasers team
+- [@evanlucas](https://github.com/evanlucas) - Evan Lucas
 - [@rvagg](https://github.com/rvagg) - Rod Vagg
 
 #### CITGM team


### PR DESCRIPTION
This is to keep the list up to date. Requested in
https://github.com/nodejs/Release/issues/499#issuecomment-555097166