### PR TITLE
Fix markdown reference to Marking as LTS

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ In coordination with a new *odd-numbered* major release being cut, the
 previous *even-numbered* major version will transition to the Long Term Support
 plan. The transition to Long Term Support can happen either before or after
 the new major version is cut in a Semver-Minor release following
-[the process documented below])(#marking-a-release-line-as-lts).
+[the process documented below](#marking-a-release-line-as-lts).
 
 Every major version covered by the LTS plan will be actively maintained for a
 period of 12 months from the date it enters LTS coverage. Following those 12


### PR DESCRIPTION
Noticed a markdown reference wasn't working as intended while skimming through the README.. A tiny `)` had slipped into the markdown reference in the wrong place near the Marking a Release Line as LTS section.

<img width="741" alt="Screenshot 2019-12-16 at 14 50 19" src="https://user-images.githubusercontent.com/1231635/70912334-03002f80-2014-11ea-9210-edae100703a3.png">
