### PR TITLE
doc: add Maintenance start date for Node 10

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 
 | Release  | Status              | Codename    |Initial Release | Active LTS Start | Maintenance Start | End-of-life                |
 | :--:     | :---:               | :---:       | :---:          | :---:            | :---:                 | :---:                     |
-| [10.x][] | **Active LTS**      | [Dubnium][] | 2018-04-24     | 2018-10-30       | April 2020            | April 2021                |
+| [10.x][] | **Active LTS**      | [Dubnium][] | 2018-04-24     | 2018-10-30       | 2020-04-30            | April 2021                |
 | [12.x][] | **Active LTS**      | [Erbium][]  | 2019-04-23     | 2019-10-21       | October 2020          | April 2022                |
 | 13.x     | **Current**         |             | 2019-10-22     |                  |                       | June 2020                 |
 | 14.x     | **Pending**         |             | April 2020     | October 2020     | October 2021          | April 2023                |

--- a/schedule.json
+++ b/schedule.json
@@ -46,7 +46,7 @@
   "v10": {
     "start": "2018-04-24",
     "lts": "2018-10-30",
-    "maintenance": "2020-04-01",
+    "maintenance": "2020-04-30",
     "end": "2021-04-30",
     "codename": "Dubnium"
   },


### PR DESCRIPTION
Adds the date scheduled (2020-04-30) for moving Node 10 into maintenance mode. Changes reflected in the `README.md` schedule and the `schedule.json`.

Discussed with @BethGriggs and @MylesBorins, and settled on this date.