### PR TITLE
doc: add offboarding releasers guidance

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -203,7 +203,7 @@ be entirely removed from use.
 
 *Note*: This section is specifically concerning removing members from the [@nodejs/releasers](https://github.com/orgs/nodejs/teams/releasers) team, not removing members from the overall Release WG.
 
-Releasers have access to critical infrastructure in the project - this elevated access must be restricted to active releasers. Members of the releasers team should be offboarded when they no longer intend to prepare releases. As a guideline, offboarding should be considered if a releaser has not prepared a release in the past 18 months.
+Releasers have access to critical infrastructure in the project - this elevated access must be restricted to active releasers. Members of the releasers team should be offboarded when they no longer intend to prepare releases. As a guideline, offboarding should be considered if a releaser has not prepared a release in the past 12 months.
 
 The following steps should be taken as part of the offboarding process:
 * Be removed from the GitHub [releasers team](https://github.com/orgs/nodejs/teams/releasers) in the Node.js organizations.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -199,7 +199,7 @@ be kept very secure and not shared with anyone. Any actual or suspected
 compromise of the private key should be reported immediately and the key should
 be entirely removed from use.
 
-## Offboaring releasers
+## Offboarding releasers
 
 *Note*: This section is specifically concerning removing members from the [@nodejs/releasers](https://github.com/orgs/nodejs/teams/releasers) team, not removing members from the overall Release WG.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -198,3 +198,19 @@ placed on the www server for access to the "dist" user. The private key should
 be kept very secure and not shared with anyone. Any actual or suspected
 compromise of the private key should be reported immediately and the key should
 be entirely removed from use.
+
+## Offboaring releasers
+
+*Note*: This section is specifically concerning removing members from the [@nodejs/releasers](https://github.com/orgs/nodejs/teams/releasers) team, not removing members from the overall Release WG.
+
+Releasers have access to critical infrastructure in the project - this elevated access must be restricted to active releasers. Members of the releasers team should be offboarded when they no longer intend to prepare releases. As a guideline, offboarding should be considered if a releaser has not prepared a release in the past 18 months.
+
+The following steps should be taken as part of the offboarding process:
+* Be removed from the GitHub [releasers team](https://github.com/orgs/nodejs/teams/releasers) in the Node.js organizations.
+* Be removed from the GitHub [security-release team](https://github.com/orgs/nodejs/teams/security-release) in the Node.js and nodejs-private organizations.
+* Ensure their SSH key is removed from the `dist` user on the primary www server.
+* Move their GPG key in nodejs/node [README.md](https://github.com/nodejs/node/#release-team) to the 'Other keys used to sign some previous releases' section.
+* Open a PR in [nodejs/docker-node](https://github.com/nodejs/docker-node/) to remove their GPG key from [node.keys](https://github.com/nodejs/docker-node/blob/master/keys/node.keys).
+* Ensure they are moved to 'Emeritus - Releasers team' in the nodejs/release [README](https://github.com/nodejs/Release/blob/master/README.md).
+
+Releasers are not automatically removed from the wider Release WG.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -209,7 +209,7 @@ The following steps should be taken as part of the offboarding process:
 * Be removed from the GitHub [releasers team](https://github.com/orgs/nodejs/teams/releasers) in the Node.js organizations.
 * Be removed from the GitHub [security-release team](https://github.com/orgs/nodejs/teams/security-release) in the Node.js and nodejs-private organizations.
 * Ensure their SSH key is removed from the `dist` user on the primary www server.
-* Move their GPG key in nodejs/node [README.md](https://github.com/nodejs/node/#release-team) to the 'Other keys used to sign some previous releases' section.
+* Move their GPG key in nodejs/node [README.md](https://github.com/nodejs/node/#release-keys) to the 'Other keys used to sign some previous releases' section.
 * Open a PR in [nodejs/docker-node](https://github.com/nodejs/docker-node/) to remove their GPG key from [node.keys](https://github.com/nodejs/docker-node/blob/master/keys/node.keys).
 * Ensure they are moved to 'Emeritus - Releasers team' in the nodejs/release [README](https://github.com/nodejs/Release/blob/master/README.md).
 


### PR DESCRIPTION
Creating an offboarding policy for @nodejs/releasers  has been on our list for a while (https://github.com/nodejs/Release/issues/542), so I thought i'd take a first cut.

Also somewhat related: https://github.com/nodejs/Release/issues/499
