### PR TITLE
doc: update status for Node.js 16

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 | :--:     | :---:               | :---:       | :---:          | :---:            | :---:             | :---:                     |
 | [12.x][] | **Maintenance**     | [Erbium][]  | 2019-04-23     | 2019-10-21       | 2020-11-30        | 2022-04-30                |
 | [14.x][] | **Maintenance**     | [Fermium][] | 2020-04-21     | 2020-10-27       | 2021-10-19        | 2023-04-30                |
-| [16.x][] | **Current**         |             | 2021-04-20     | 2021-10-26       | 2022-10-18        | 2024-04-30                |
+| [16.x][] | **Active LTS**      | [Gallium][] | 2021-04-20     | 2021-10-26       | 2022-10-18        | 2024-04-30                |
 | [17.x][] | **Current**         |             | 2021-10-19     | -                | 2022-04-01        | 2022-06-01                |
 | 18.x     | **Pending**         |             | 2022-04-19     | 2022-10-25       | 2023-10-18        | 2025-04-30                |
 
@@ -146,6 +146,7 @@ the discretion of the Release working group.
 [Dubnium]: https://nodejs.org/download/release/latest-dubnium/
 [Erbium]: https://nodejs.org/download/release/latest-erbium/
 [Fermium]: https://nodejs.org/download/release/latest-fermium/
+[Gallium]: https://nodejs.org/download/release/latest-gallium/
 [4.x]: https://nodejs.org/download/release/latest-v4.x/
 [5.x]: https://nodejs.org/download/release/latest-v5.x/
 [6.x]: https://nodejs.org/download/release/latest-v6.x/

--- a/schedule.json
+++ b/schedule.json
@@ -88,7 +88,7 @@
     "lts": "2021-10-26",
     "maintenance": "2022-10-18",
     "end": "2024-04-30",
-    "codename": ""
+    "codename": "Gallium"
   },
   "v17": {
     "start": "2021-10-19",


### PR DESCRIPTION
Node.js 16 has now transitioned to Long Term Support with codename
'Gallium'.

---

Not to be merged until after the LTS transition (2021-10-26).