### PR TITLE
Move myself from CITGM to CITGM Emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -221,7 +221,6 @@ and CITGM team members listed below.
 <!-- ncu-team-sync.team(nodejs/citgm) -->
 
 - [@al-k21](https://github.com/al-k21) - Oleksandr Kushchak
-- [@bengl](https://github.com/bengl) - Bryan English
 - [@BridgeAR](https://github.com/BridgeAR) - Ruben Bridgewater
 - [@bzoz](https://github.com/bzoz) - Bartosz Sosnowski
 - [@gdams](https://github.com/gdams) - George Adams
@@ -256,5 +255,6 @@ and CITGM team members listed below.
 - [@rvagg](https://github.com/rvagg) - Rod Vagg
 
 ### CITGM team
+- [@bengl](https://github.com/bengl) - Bryan English
 - [@gibfahn](https://github.com/gibfahn) - Gibson Fahnestock
 - [@jasnell](https://github.com/jasnell) - James M Snell


### PR DESCRIPTION
While I had an initial flurry of activity on the CITGM project (5 years ago I think?) I haven't been involved with it since then. While I don't want to rule out any future activity, it's probably well overdue that I step down from that team more officially since my activity there is zero and has been for years. It's certainly possible (maybe even likely?) that this should be reversed in the future, but I'd rather reflect reality now, even if it's several years late.

I couldn't find an offboarding process for CITGM specifically, so I assume this PR suffices. Once it lands, I'll remove myself from the @nodejs/citgm .