### PR TITLE
Rename 18.x LTS to Hafnium

### DIFF
--- a/CODENAMES.md
+++ b/CODENAMES.md
@@ -8,7 +8,7 @@ releases are subject to change.
 * Erbium (12.x 2019)
 * Fermium (14.x 2020)
 * Gallium (16.x 2021)
-* Hydrogen (18.x 2022)
+* Hafnium (18.x 2022)
 * Iron (20.x 2023)
 
 The release schedule is available as a [JSON](./schedule.json) file.


### PR DESCRIPTION
- Continues the `-ium` pattern in use since 10.x
- Hafnium has an atomic number of 72, which is 4 * 18, and its most abundant isotope has an atomic mass of 180
- Hafnium-based compounds have been used in semiconductors