### PR TITLE
chore: move inactive releasers to emeritus

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,13 +209,8 @@ and CITGM team members listed below.
 
 * [@bengl](https://github.com/bengl) - Bryan English
 * [@BethGriggs](https://github.com/BethGriggs) - Bethany Nicolle Griggs
-* [@BridgeAR](https://github.com/BridgeAR) - Ruben Bridgewater
-* [@cjihrig](https://github.com/cjihrig) - Colin Ihrig
-* [@codebytere](https://github.com/codebytere) - Shelley Vohr
 * [@danielleadams](https://github.com/danielleadams) - Danielle Adams
-* [@jasnell](https://github.com/jasnell) - James M Snell
 * [@juanarbol](https://github.com/juanarbol) - Juan José
-* [@MylesBorins](https://github.com/MylesBorins) - Myles Borins
 * [@RafaelGSS](https://github.com/RafaelGSS) - Rafael Gonzaga
 * [@richardlau](https://github.com/richardlau) - Richard Lau
 * [@ruyadorno](https://github.com/ruyadorno) - Ruy Adorno
@@ -256,9 +251,14 @@ and CITGM team members listed below.
 - [@yunong](https://github.com/yunong) - Yunong Xiao
 
 ### Releasers team
+- [@BridgeAR](https://github.com/BridgeAR) - Ruben Bridgewater
+- [@cjihrig](https://github.com/cjihrig) - Colin Ihrig
+- [@codebytere](https://github.com/codebytere) - Shelley Vohr
 - [@evanlucas](https://github.com/evanlucas) - Evan Lucas
 - [@Fishrock123](https://github.com/Fishrock123) - Jeremiah Senkpiel
 - [@gibfahn](https://github.com/gibfahn) - Gibson Fahnestock
+- [@jasnell](https://github.com/jasnell) - James M Snell
+- [@MylesBorins](https://github.com/MylesBorins) - Myles Borins
 - [@rvagg](https://github.com/rvagg) - Rod Vagg
 
 ### CITGM team

--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ and CITGM team members listed below.
 * [@BethGriggs](https://github.com/BethGriggs) - Bethany Nicolle Griggs
 * [@danielleadams](https://github.com/danielleadams) - Danielle Adams
 * [@juanarbol](https://github.com/juanarbol) - Juan José
+* [@MylesBorins](https://github.com/MylesBorins) - Myles Borins
 * [@RafaelGSS](https://github.com/RafaelGSS) - Rafael Gonzaga
 * [@richardlau](https://github.com/richardlau) - Richard Lau
 * [@ruyadorno](https://github.com/ruyadorno) - Ruy Adorno
@@ -258,7 +259,6 @@ and CITGM team members listed below.
 - [@Fishrock123](https://github.com/Fishrock123) - Jeremiah Senkpiel
 - [@gibfahn](https://github.com/gibfahn) - Gibson Fahnestock
 - [@jasnell](https://github.com/jasnell) - James M Snell
-- [@MylesBorins](https://github.com/MylesBorins) - Myles Borins
 - [@rvagg](https://github.com/rvagg) - Rod Vagg
 
 ### CITGM team


### PR DESCRIPTION
"Releasers have access to critical infrastructure in the project - this elevated access must be restricted to active releasers. Members of the releasers team should be offboarded when they no longer intend to prepare releases. As a guideline, offboarding should be considered if a releaser has not prepared a release in the past 12 months."

Refs: https://github.com/nodejs/Release/blob/main/GOVERNANCE.md#offboarding-releasers