### PR TITLE
doc: add codenames through to Node.js 34 (2030)

### DIFF
--- a/CODENAMES.md
+++ b/CODENAMES.md
@@ -11,5 +11,11 @@ releases are subject to change.
 * Hydrogen (18.x 2022)
 * Iron (20.x 2023)
 * Jod (22.x 2024)
+* Krypton (24.x 2025)
+* Lithium (26.x 2026)
+* Magnesium (28.x 2027)
+* Neon (30.x 2028)
+* Oxygen (32.x 2029)
+* Platinum (34.x 2030)
 
 The release schedule is available as a [JSON](./schedule.json) file.


### PR DESCRIPTION
Extend codenames for a further six releases through to Node.js 34, which takes us to 2030.

By convention, all of our long term support codenames have been chemical elements.

No immediate rush to land this (we have Jod for Node.js 22 next year). I'll leave some alternative suggestions (existing elements) as in-line reviews.