### PR TITLE
doc: add codenames through to Node.js 54 (2040)

### DIFF
--- a/CODENAMES.md
+++ b/CODENAMES.md
@@ -17,5 +17,15 @@ releases are subject to change.
 * Neon (30.x 2028)
 * Oxygen (32.x 2029)
 * Platinum (34.x 2030)
+* Quartz (36.x 2031)
+* Radium (38.x 2032)
+* Silicon (40.x 2033)
+* Titanium (42.x 2034)
+* Unbibium (44.x 2035)
+* Vanadium (46.x 2036)
+* Wolfram (48.x 2037)
+* Xenon (50.x 3038
+* Yttrium (52.x 2039)
+* Zinc (54.x 2040)
 
 The release schedule is available as a [JSON](./schedule.json) file.


### PR DESCRIPTION
Hi, I'm really looking to contribute to Node.js development. I'd like to help out every now and then by adding codenames after P. Feel free to close this request if you don't think it's time yet. 

One of the code names (Quartz) does not come from the periodic table. References: 
- Q (Quartz): https://en.m.wikipedia.org/wiki/Quartz
- R (Radium): https://en.m.wikipedia.org/wiki/Radium
- S (Silicon): https://en.m.wikipedia.org/wiki/Silicon
- T (Titanium): https://en.m.wikipedia.org/wiki/Titanium
- U (Unbibium): https://en.m.wikipedia.org/wiki/Unbibium
- V (Vanadium): https://en.m.wikipedia.org/wiki/Vanadium
- W (Wolfram, English: Tungsten): https://en.m.wikipedia.org/wiki/Tungsten
- X (Xenon): https://en.m.wikipedia.org/wiki/Xenon
- Y (Yttrium): https://en.m.wikipedia.org/wiki/Yttrium
- Z (Zinc): https://en.m.wikipedia.org/wiki/Zinc 