### PR TITLE
add minutes for 2026-02-05, 2026-03-05 and 2026-06-25

### DIFF
--- a/doc/meetings/2026-02-05.md
+++ b/doc/meetings/2026-02-05.md
@@ -1,0 +1,47 @@
+# Node.js Release WorkGroup Meeting 2026-02-05
+
+## Links
+
+* **Recording**:  
+* **GitHub Issue**: https://github.com/nodejs/Release/issues/1140
+* **Minutes**: https://hackmd.io/@openjs-nodejs/HJrlyYYU-l
+
+## Present
+
+* Antoine
+* Marco
+* Richard
+* Ruy
+* Ulises
+
+
+## Agenda
+
+## Announcements
+
+*Extracted from **Release-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+### nodejs/Release
+
+* Release plan - v25.x Current [#1122](https://github.com/nodejs/Release/issues/1122)
+  * Richard volunteered for release around beginning of March.
+* Proposal - Shift Node.js to Annual Major Releases and Shorten LTS Duration [#1113](https://github.com/nodejs/Release/issues/1113)
+  * Ulises suggested having an early blog post for awareness and early feedback.
+* Release plan - v24.x Current [#1089](https://github.com/nodejs/Release/issues/1089)
+  * Build up of commits on staging branch.
+* Release plan - v22.x Maintenance LTS [#1001](https://github.com/nodejs/Release/issues/1001)
+* Proposal for new release schedule / users are not interested in releases that will not become LTS  [#953](https://github.com/nodejs/Release/issues/953)
+* Release plan - v20.x Maintenance LTS [#855](https://github.com/nodejs/Release/issues/855)
+  * Marco volunteered to do a release end of February/beginning of March.
+
+### nodejs/node
+
+* tools: add a backport queue cron action [#56143](https://github.com/nodejs/node/pull/56143)
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Node.js Project Calendar**: <https://nodejs.org/calendar>
+
+Click `Add to Google Calendar` at the bottom left to add to your own Google calendar.

--- a/doc/meetings/2026-03-05.md
+++ b/doc/meetings/2026-03-05.md
@@ -1,0 +1,64 @@
+# Node.js Release WorkGroup Meeting 2026-03-05
+
+## Links
+
+* **Recording**:  
+* **GitHub Issue**: https://github.com/nodejs/Release/issues/1141
+* **Minutes**: https://hackmd.io/@openjs-nodejs/r1VSFv0_Ze
+
+## Present
+
+* Antoine
+* Juan
+* Marco
+* Rafael
+* Richard
+* Ruy
+
+
+## Agenda
+
+## Announcements
+
+*Extracted from **Release-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+Releases of:
+
+* v25.8.0
+* v22.22.1 
+* v20.20.1
+
+### nodejs/nodejs.org
+
+* Blog: Evolving the Node.js Release Schedule [#8631](https://github.com/nodejs/nodejs.org/pull/8631)
+  * Ping Ulises to know what are the reasons to not land that as soon as possible.
+
+### nodejs/Release
+
+* Release plan - v25.x Current [#1122](https://github.com/nodejs/Release/issues/1122)
+  * Included Rafael name on the queue for the next v25 release.
+
+* Release plan - v24.x Current [#1089](https://github.com/nodejs/Release/issues/1089)
+
+* Release plan - v22.x Maintenance LTS [#1001](https://github.com/nodejs/Release/issues/1001)
+  * There's a npm security release that we might make us to issue a new release of v22.x. This won't be necessary for v20 as it will be EOL.
+  
+* Release plan - v20.x Maintenance LTS [#855](https://github.com/nodejs/Release/issues/855)
+  * Discussion on backporting npm 10 to v20. Richard provide some
+information on what prevent us to backport npm 10 to v20 line.
+
+* Proposal - Shift Node.js to Annual Major Releases and Shorten LTS Duration [#1113](https://github.com/nodejs/Release/issues/1113)
+* Proposal for new release schedule / users are not interested in releases that will not become LTS  [#953](https://github.com/nodejs/Release/issues/953)
+
+### nodejs/node
+
+* tools: add a backport queue cron action [#56143](https://github.com/nodejs/node/pull/56143)
+  * No updates this week
+
+## Q&A, Other
+
+## Upcoming Meetings
+
+* **Node.js Project Calendar**: <https://nodejs.org/calendar>
+
+Click `Add to Google Calendar` at the bottom left to add to your own Google calendar.

--- a/doc/meetings/2026-06-25.md
+++ b/doc/meetings/2026-06-25.md
@@ -1,0 +1,74 @@
+# Node.js Release WorkGroup Meeting 2026-06-25
+
+## Links
+
+* **Recording**: None as no-one had the access to stream to youtube. sxa will look at gaining access/info for the future   
+* **GitHub Issue**: https://github.com/nodejs/Release/issues/1162
+* **Minutes**: https://hackmd.io/@openjs-nodejs/S1hP5fzGfe
+
+## Present
+
+* Antoine
+* Marco
+* Michael
+* Richard
+* Ruy
+* Stewart
+* Jamie Magee
+
+## Agenda
+
+## Announcements
+
+*Extracted from **Release-agenda** labelled issues and pull requests from the **nodejs org** prior to the meeting.
+
+### nodejs/TSC
+
+* OpenSSL LTS strategy alignment with future Node majors [#1869](https://github.com/nodejs/TSC/issues/1869)
+  * Richard relayed some of the discussions and summaries similar to what was in the TSC call this week
+  * No objections to option 4 (aim to have Node 27.0.0 released with OpenSSL 4.1 then update to the LTS 4.2 before Node 27 becomes LTS) so unless anything changes we will proceed with that approach
+
+### nodejs/Release
+
+* Plans for npm 12 [#1161](https://github.com/nodejs/Release/issues/1161)
+  * Lots of discussion on the background and concerns
+    - Security changes affect postinstall scripts so this should be considered a SEMVER-MAJOR change
+    - The breaking changes directly address the Sha1-Hulud vulnerability
+    - The same restrictions could be applied to the default configuration on NPM11
+    - Conversely the new restrictions could be relaxed in a default configuration in NPM12, although concerns were raised regarding likely node-gyp compatibility of such an approach
+    - There was also a request that we ensure that the documentation is consistent with the current policies regarding upgrades: https://github.com/npm/cli/wiki/Integrating-with-node
+    - Jamie has been reaching out to some of the top packages' maintainers to assess the likely impact of such a change. Most are favourable towards it, and for most the install scripts are optional rather than required.
+  * Continue discussion async. in Slack release channels
+* Alpha phase for Node.js 27 unexplained [#1160](https://github.com/nodejs/Release/issues/1160)
+  * PRs welcome to update other documentation.
+  * Any lack of clarity on some points is because they haven't been finalised first but we should continue to refine the requirements to provide clarty for consumers of the releases.
+  * We should update docs sooner and interatively as things are clarified and get ongoing feedback/refinement.
+  * What would be the versioning style during Alpha period [#1154](https://github.com/nodejs/Release/issues/1154) - feedback requested
+* Release plan – v26.x Current [#1152](https://github.com/nodejs/Release/issues/1152)
+* Release plan - v24.x Active LTS [#1089](https://github.com/nodejs/Release/issues/1089)
+* Release plan - v22.x Maintenance LTS [#1001](https://github.com/nodejs/Release/issues/1001)
+* Onboarding sxa as a releaser [#733](https://github.com/nodejs/Release/issues/733)
+  - No objections - will aim to progress getting suitable GPG keys added where required and completing the checklist in the issue
+
+### nodejs/node
+
+* meta: add support for alpha prerelease tag [#63135](https://github.com/nodejs/node/pull/63135)
+  * Please review.
+
+## Q&A, Other
+
+ * Request from Antoine in Slack to be able to schedule release builds on the CI instead of manual initiation
+   - Discussion on how how we can reduce time to perform the release builds including potentially cache warming on the release machines, although there were no objections to the idea in principle of being able to schedule them.
+   - Scheduling would allow the builds  to have the "expected" build stamps etc. and be ready earlier for publication.
+   - The date in `index.json`/`index.tab` is based on the modified time of the files so may not match the date in the changelog/release notes if all of the files were staged on an earlier day.
+   - Having three Linux/x64 agents was raised as a concern due to cache invalidation taking longer to fix across more machines. Two are currently used during the build (main build and sources - could they be combined?)
+   - Currently somewhat problematic trying to get a green CI and release done within one day.
+ * Also a suggestion was made for releasers to actively cancel any V8 canary builds (iojs+release from the nodejs/node-v8 repo) running during release cycles to avoid delays due to executors being used for those.
+ * Alpine's move to tier 2 has been approved. We could potentially reallocate one of the three Linux/x64 machines for Alpine
+   - Alpine version needs to be determined (issue with that vs node support timeframes) and decide on static vs dynamic containers for the release builds.
+
+## Upcoming Meetings
+
+* **Node.js Project Calendar**: <https://nodejs.org/calendar>
+
+Click `Add to Google Calendar` at the bottom left to add to your own Google calendar.


### PR DESCRIPTION
The 2026-06-25 was written by me. I've added two others which had not been pushed up to this repository. I don't think 2026-05-28 meeting happened so I haven't included that. I'll leave this out for view for a few days before merging in case anyone wants to comment/correct anything here (If there are recordings for the first two please suggest a change with the link - there was no recording of this week's one because I didn't have access to it, which I am looking to address for next time in case I need to host in the future)

Adding anyone team members who was in the meetings as reviewers :-)

Also FYI @JamieMagee as you were in attendance this week.